### PR TITLE
Add Wayland permissions

### DIFF
--- a/org.jflap.JFLAP.yml
+++ b/org.jflap.JFLAP.yml
@@ -10,7 +10,9 @@ sdk-extensions:
 finish-args:
   # X11 + XShm access
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
+  # Wayland access with X11 fallback
+  - --socket=wayland
   # GPU acceleration if needed
   - --device=dri
   # Jflap does not have support for portals :(


### PR DESCRIPTION
This PR enables Wayland by default in the sandbox. It also adds X11 as a fallback in case Wayland isn't supported.

On my end, overriding the current Flatpak's permissions to enable Wayland does not give me issues, at least on Arch Linux under Plasma 6. Therefore, I hope these changes are okay to merge as-is.